### PR TITLE
Route `NSWindowTemplate` with custom module through `IBClassReference`

### DIFF
--- a/ibtool/models.py
+++ b/ibtool/models.py
@@ -787,7 +787,7 @@ def _xibparser_handle_custom_class(ctx: ArchiveContext, elem: Element, obj: "Xib
             obj["IBClassReference"] = make_class_reference(custom_class, custom_module, custom_module_provider)
     elif custom_class:
         #print(obj.xibid, obj.originalclassname(), obj.classname(), custom_class)
-        if (ctx.customObjectInstantitationMethod == "direct" and not (obj.originalclassname() == "NSWindowTemplate" and not custom_module) and not (obj.originalclassname() == "NSCustomObject" and not custom_module and custom_class in _CUSTOM_OBJECT_NO_SWAP)) or obj.originalclassname() in ("NSView", "NSOutlineView", "NSButton", "NSTextField", "NSTextView", "NSProgressIndicator", "NSTableView", "NSTableHeaderView", "NSPopUpButtonCell", "NSScrollView", "NSLevelIndicatorCell", "NSImageView", "NSTableCellView", "NSCustomFormatter", "NSNumberFormatter", "NSSplitView", "NSTextFieldCell", "NSSearchFieldCell", "NSToolbarItem"):
+        if (ctx.customObjectInstantitationMethod == "direct" and obj.originalclassname() != "NSWindowTemplate" and not (obj.originalclassname() == "NSCustomObject" and not custom_module and custom_class in _CUSTOM_OBJECT_NO_SWAP)) or obj.originalclassname() in ("NSView", "NSOutlineView", "NSButton", "NSTextField", "NSTextView", "NSProgressIndicator", "NSTableView", "NSTableHeaderView", "NSPopUpButtonCell", "NSScrollView", "NSLevelIndicatorCell", "NSImageView", "NSTableCellView", "NSCustomFormatter", "NSNumberFormatter", "NSSplitView", "NSTextFieldCell", "NSSearchFieldCell", "NSToolbarItem"):
             #print("direct")
             if custom_module:
                 obj["NSClassName"] = NibString.intern(f"_TtC{len(custom_module)}{custom_module}{len(custom_class)}{custom_class}")


### PR DESCRIPTION
Ghostty's Terminal window xibs declare `NSWindow` subclasses (e.g. `TerminalWindow`) with `customModule="Ghostty"`. The old guard only bypassed the class-swapper direct path when no custom module was set, so module-qualified templates were NSClassSwapper'd and didn't match Apple's ibtool output

Drop the module check so `NSWindowTemplate` always takes the `IBClassReference` branch